### PR TITLE
Feature/expose version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {},
   "jest": {
+    "moduleNameMapper": {
+      "^@pipe-dream/(.*)$": "<rootDir>/node_modules/@pipe-dream/$1"
+    },    
     "moduleFileExtensions": [
       "js",
       "json",
@@ -27,13 +30,19 @@
     "transform": {
       ".*\\.(js)$": "babel-jest",
       ".*\\.(vue)$": "vue-jest"
-    }
+    },
+    "testMatch": [
+      "<rootDir>/(test/**/*.js)"
+    ],
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@pipe-dream/core).+\\.js$"
+    ]    
   },
   "dependencies": {
     "@pipe-dream/core": "^1.0.3",
     "@vue/test-utils": "^1.0.0-beta.29",
-    "babel-core": "^6.26.3",
-    "babel-jest": "^24.8.0",
+    "babel-core": "7.0.0-bridge.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "change-case": "^3.1.0",

--- a/src/LaravelFileFactory.js
+++ b/src/LaravelFileFactory.js
@@ -6,7 +6,7 @@ import SampleAppSketchButton from './utilities/sketchButtons/SampleApp'
 
 import templates from './templates/compiledTemplates'
 
-const pipes = require.context('./pipes', false, /\.js$/);
+import UserPipe from './pipes/UserPipe'
 
 export default class LaravelFileFactory {
     constructor(objectModelCollection) {
@@ -14,11 +14,15 @@ export default class LaravelFileFactory {
     }
 
     static get title() {
-        return "Laravel"
+        return "Laravel" + LaravelFileFactory.version()
     }
 
     static templates() {
         return templates
+    }
+
+    static version() {
+        return require('../package.json').version;
     }
 
     static buttons() {
@@ -43,17 +47,8 @@ export default class LaravelFileFactory {
     }
 
     static pipes() {
-        //return pipes.keys().filter(key => !key.includes('BasePipe')).map(key => pipes(key).default)
-
         return [
-             pipes("./UserPipe.js").default,
-        //     pipes("./ModelPipe.js").default,
-        //     pipes("./MigrationPipe.js").default,
-        //     pipes("./ControllerPipe.js").default,
-        //     pipes("./APIControllerPipe.js").default,
-        //     pipes("./SeederPipe.js").default,            
-        //     pipes("./FactoryPipe.js").default,                        
-        //     pipes("./APIRoutesPipe.js").default,            
+            UserPipe
         ]
     }
 

--- a/src/LaravelFileFactory.js
+++ b/src/LaravelFileFactory.js
@@ -14,7 +14,7 @@ export default class LaravelFileFactory {
     }
 
     static get title() {
-        return "Laravel" + LaravelFileFactory.version()
+        return "LaravelFileFactory"
     }
 
     static templates() {

--- a/test/LaravelFileFactory/LaravelFileFactory.test.js
+++ b/test/LaravelFileFactory/LaravelFileFactory.test.js
@@ -1,0 +1,11 @@
+import LaravelFileFactory from 'LaravelFileFactory';
+
+describe("LaravelFileFactory", () => {
+
+  test('it should expose a version following pattern 0.1.2', () => {
+    expect.stringMatching(
+        LaravelFileFactory.version(),
+        /^[\d]*\.[\d]*\.[\d]*$/
+    )    
+  });
+});

--- a/test/utilities/Formatter.test.js
+++ b/test/utilities/Formatter.test.js
@@ -1,4 +1,4 @@
-import F from 'utilities/formatter';
+import F from 'utilities/Formatter';
 
 describe("Formatter", () => {
 


### PR DESCRIPTION
* we can use `LaravelFileFactory.version()` to get the version in use.
* `yarn test` working again.
* Had to remove `require.context` for dynamic pipes
* Downgraded babel-jest according to this thread: https://github.com/vuejs/vue-cli/issues/1584
