### PR TITLE
Added Policy pipe.

### DIFF
--- a/src/LaravelFileFactory.js
+++ b/src/LaravelFileFactory.js
@@ -18,6 +18,7 @@ import MigrationPipe from './pipes/MigrationPipe'
 import ModelPipe from './pipes/ModelPipe'
 import SeederPipe from './pipes/SeederPipe'
 import UserPipe from './pipes/UserPipe'
+import PolicyPipe from './pipes/PolicyPipe'
 
 export default class LaravelFileFactory {
     constructor(objectModelCollection) {
@@ -80,6 +81,7 @@ export default class LaravelFileFactory {
             ModelPipe,
             SeederPipe,
             UserPipe,
+            PolicyPipe,
         ]
     }
 

--- a/src/pipes/PolicyPipe.js
+++ b/src/pipes/PolicyPipe.js
@@ -1,0 +1,33 @@
+import { Template } from '@pipe-dream/core/dist/pipe-dream.js'
+import ModelPipe from './ModelPipe';
+import F from '../utilities/Formatter'
+
+
+export default class PolicyPipe extends ModelPipe {
+
+    static get title() {
+        return 'PolicyPipe';
+    }
+
+    calculateFiles(omc = ObjectModelCollection) {
+        return [
+            ... this.PolicyFiles()
+        ]
+    }
+
+    PolicyFiles() {
+        return this.omc.modelsIncludingUser().map(model => {
+            return {
+                // Laravel can auto-discover policies as long as they are in a 
+                // "Policies" directory directly beneath the directory housing
+                // the models.
+                path: this.modelPath() + "/Policies/" + model.className() + "Policy.php",
+                content: Template.for('Policy.php').replace({
+                    ___MODEL___: this.className(model),
+                    ___MODEL_NAMESPACE___: this.modelNamespace(),
+                    ___RESOURCE_NAME___: F.camelCase(model.className()),            
+                })
+            }
+        })
+    }
+}

--- a/src/templates/Policy.php.stub
+++ b/src/templates/Policy.php.stub
@@ -1,0 +1,94 @@
+<?php
+
+namespace ___MODEL_NAMESPACE___\Policies;
+
+use ___MODEL_NAMESPACE___\User;
+use ___MODEL_NAMESPACE___\___MODEL___;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ___MODEL___Policy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @return bool
+     */
+    public function viewAny(User $user)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @param  ___MODEL_NAMESPACE___\___MODEL___  $___RESOURCE_NAME___
+     * @return bool
+     */
+    public function view(User $user, ___MODEL___ $___RESOURCE_NAME___)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can create a ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @return bool
+     */
+    public function create(User $user)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @param  ___MODEL_NAMESPACE___\___MODEL___  $___RESOURCE_NAME___
+     * @return bool
+     */
+    public function update(User $user, ___MODEL___ $___RESOURCE_NAME___)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @param  ___MODEL_NAMESPACE___\___MODEL___  $___RESOURCE_NAME___
+     * @return bool
+     */
+    public function delete(User $user, ___MODEL___ $___RESOURCE_NAME___)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @param  ___MODEL_NAMESPACE___\___MODEL___  $___RESOURCE_NAME___
+     * @return bool
+     */
+    public function restore(User $user, ___MODEL___ $___RESOURCE_NAME___)
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the ___RESOURCE_NAME___.
+     *
+     * @param  ___MODEL_NAMESPACE___\User  $user
+     * @param  ___MODEL_NAMESPACE___\___MODEL___  $___RESOURCE_NAME___
+     * @return bool
+     */
+    public function forceDelete(User $user, ___MODEL___ $___RESOURCE_NAME___)
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Added in a new pipe to generate model Policies.

Currently, it forces the policy files to:
1. be named {Model}Policy
2. be under the Policies directory under the modelPath()

This is so that Laravel can auto-resolve the policies so that I don't have to touch the app\Providers\AuthServiceProvider.php file. 

The alternatives are to manually register each policy in an array at the top of AuthServiceProvider or to code a custom function to auto-resolve the policy names. I personally use the latter in some of my projects, since their Policy directory is outside of the Models directory.

However, I don't see a way for PipeDream to merge templates. If another pipe wanted to manipulate AuthServiceProvider, I'm guessing there'd be a conflict (specifically, a duplicate key due to the same file path). If there is a way to merge, I can add an AuthServiceProvider template with this code:
```php
// ...

public function boot()
{
    // Merge starts here.
    Gate::guessPolicyNamesUsing(function ($modelClass) {
        return ___POLICIES_PATH___.'\\'.class_basename($modelClass).'Policy';
    });
    // Merge ends here.

    $this->registerPolicies();

    //
}

// ...
```
Where `___POLICIES_PATH___` could be added to the settings page.